### PR TITLE
Add WMS URL normalization and configuration for Fototeca

### DIFF
--- a/ckanext/fototeca/config_declaration.yml
+++ b/ckanext/fototeca/config_declaration.yml
@@ -17,3 +17,10 @@ groups:
         description: |
           Field name of the ckanext-fototeca schema that using to alternate_identifier in Postgres Harvester.
         required: false
+
+      - key: ckanext.fototeca.postgres.wms_base_url
+        default: https://wms-fototeca.idee.es/fototeca
+        validators:
+        description: |
+          Base URL of WMS service of Fototeca.
+        required: false  


### PR DESCRIPTION
- Introduced a new configuration key for WMS base URL in config_declaration.yml.
- Implemented normalize_wms_url function to format WMS URLs.
- Added check_wms_url function to validate WMS resources.
- Updated normalize_resources function to filter and normalize WMS URLs.